### PR TITLE
Removed authentication from /movies endpoint

### DIFF
--- a/index.js
+++ b/index.js
@@ -227,7 +227,7 @@ app.delete(
 
 app.get(
   "/movies",
-  passport.authenticate("jwt", { session: false }),
+  // passport.authenticate("jwt", { session: false }),
   async (req, res) => {
     console.log("Authenticated User:", req.user);
     try {


### PR DESCRIPTION
- Removed JWT authentication middleware from the /movies route.
- The endpoint is now publicly accessible.